### PR TITLE
Changed the structure of `jhtdb-config.json`

### DIFF
--- a/config-files/jhtdb-config.json
+++ b/config-files/jhtdb-config.json
@@ -60,7 +60,7 @@
       "code": "n",
       "name": "eddyviscosity",
       "description": null,
-      "cardinality": 1  
+      "cardinality": 1
     }
   ],
   "spatial_operators": [
@@ -186,125 +186,122 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "p",
-        "o"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "o",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "p",
-          "methods": [
+          "code": "p",
+          "name": "Pressure",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "o",
-          "methods": [
+          "code": "o",
+          "name": "Position",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "pchip"
           ]
         }
@@ -341,107 +338,102 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "p"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         },
         {
-          "variable": "p",
-          "methods": [
+          "code": "p",
+          "name": "Pressure",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         }
@@ -478,145 +470,144 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "p",
-        "o",
-        "f"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "o",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8"
-          ]
-        },
-        {
-          "variable": "f",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "p",
-          "methods": [
+          "code": "p",
+          "name": "Pressure",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "o",
-          "methods": [
+          "code": "o",
+          "name": "Position",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "pchip"
           ]
         },
         {
-          "variable": "f",
-          "methods": [
+          "code": "f",
+          "name": "Force",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
@@ -654,145 +645,144 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "p",
-        "o",
-        "f"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "o",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8"
-          ]
-        },
-        {
-          "variable": "f",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "p",
-          "methods": [
+          "code": "p",
+          "name": "Pressure",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "o",
-          "methods": [
+          "code": "o",
+          "name": "Position",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "pchip"
           ]
         },
         {
-          "variable": "f",
-          "methods": [
+          "code": "f",
+          "name": "Force",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
@@ -830,62 +820,57 @@
       },
       "description": null,
       "physical_variables": [
-        "u"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         }
@@ -922,99 +907,94 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "p"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         },
         {
-          "variable": "p",
-          "methods": [
+          "code": "p",
+          "name": "Pressure",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         }
@@ -1051,177 +1031,172 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "p",
-        "t",
-        "e"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8"
-          ]
-        },
-        {
-          "variable": "t",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8"
-          ]
-        },
-        {
-          "variable": "e",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "t",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "e",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint"
-          ]
-        },
-        {
-          "variable": "t",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint"
-          ]
-        },
-        {
-          "variable": "e",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         },
         {
-          "variable": "p",
-          "methods": [
+          "code": "p",
+          "name": "Pressure",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         },
         {
-          "variable": "t",
-          "methods": [
+          "code": "t",
+          "name": "Temperature",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         },
         {
-          "variable": "e",
-          "methods": [
+          "code": "e",
+          "name": "Subgrid-scale Energy",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         }
@@ -1258,180 +1233,175 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "p",
-        "t",
-        "e"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8"
-          ]
-        },
-        {
-          "variable": "t",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8"
-          ]
-        },
-        {
-          "variable": "e",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "t",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "e",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint"
-          ]
-        },
-        {
-          "variable": "t",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint"
-          ]
-        },
-        {
-          "variable": "e",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "p",
-          "methods": [
+          "code": "p",
+          "name": "Pressure",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "t",
-          "methods": [
+          "code": "t",
+          "name": "Temperature",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "e",
-          "methods": [
+          "code": "e",
+          "name": "Subgrid-scale Energy",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
@@ -1469,257 +1439,254 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "p",
-        "b",
-        "a",
-        "o",
-        "f"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "b",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "a",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "o",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8"
-          ]
-        },
-        {
-          "variable": "f",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "b",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "a",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "b",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "a",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "b",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "a",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "p",
-          "methods": [
+          "code": "p",
+          "name": "Pressure",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "b",
-          "methods": [
+          "code": "b",
+          "name": "Magnetic Field",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "a",
-          "methods": [
+          "code": "a",
+          "name": "Vector Potential",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "o",
-          "methods": [
+          "code": "o",
+          "name": "Position",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "pchip"
           ]
         },
         {
-          "variable": "f",
-          "methods": [
+          "code": "f",
+          "name": "Force",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
@@ -1757,171 +1724,168 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "p",
-        "d",
-        "o"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "d",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "o",
-          "operator": "f",
-          "methods": [
-            "lag4",
-            "lag6",
-            "lag8"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "d",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "d",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "p",
-          "methods": [
+          "code": "p",
+          "name": "Pressure",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "d",
-          "methods": [
+          "code": "d",
+          "name": "Density",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "o",
-          "methods": [
+          "code": "o",
+          "name": "Position",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4",
+                "lag6",
+                "lag8"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "pchip"
           ]
         }
@@ -1958,107 +1922,102 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "t"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "t",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4",
-            "lag6",
-            "lag8",
-            "m1q4",
-            "m2q8",
-            "m2q14"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "t",
-          "operator": "g",
-          "methods": [
-            "m1q4",
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "t",
-          "operator": "h",
-          "methods": [
-            "m2q8",
-            "m2q14",
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd6noint",
-            "fd8noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         },
         {
-          "variable": "t",
-          "methods": [
+          "code": "t",
+          "name": "Temperature",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4",
+                "lag6",
+                "lag8",
+                "m1q4",
+                "m2q8",
+                "m2q14"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "m1q4",
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "m2q8",
+                "m2q14",
+                "fd4noint",
+                "fd6noint",
+                "fd8noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none"
           ]
         }
@@ -2095,93 +2054,90 @@
       },
       "description": null,
       "physical_variables": [
-        "u",
-        "p",
-        "o"
-      ],
-      "variable_operator_methods": [
         {
-          "variable": "u",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "f",
-          "methods": [
-            "none",
-            "lag4"
-          ]
-        },
-        {
-          "variable": "o",
-          "operator": "f",
-          "methods": [
-            "lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "g",
-          "methods": [
-            "fd4noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "g",
-          "methods": [
-            "fd4noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "h",
-          "methods": [
-            "fd4noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "p",
-          "operator": "h",
-          "methods": [
-            "fd4noint",
-            "fd4lag4"
-          ]
-        },
-        {
-          "variable": "u",
-          "operator": "l",
-          "methods": [
-            "fd4noint",
-            "fd4lag4"
-          ]
-        }
-      ],
-      "variable_time_methods": [
-        {
-          "variable": "u",
-          "methods": [
+          "code": "u",
+          "name": "Velocity",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "fd4noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "fd4noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "l",
+              "methods": [
+                "fd4noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "p",
-          "methods": [
+          "code": "p",
+          "name": "Pressure",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "none",
+                "lag4"
+              ]
+            },
+            {
+              "operator": "g",
+              "methods": [
+                "fd4noint",
+                "fd4lag4"
+              ]
+            },
+            {
+              "operator": "h",
+              "methods": [
+                "fd4noint",
+                "fd4lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "none",
             "pchip"
           ]
         },
         {
-          "variable": "o",
-          "methods": [
+          "code": "o",
+          "name": "Position",
+          "grided": false,
+          "variable_operator_methods": [
+            {
+              "operator": "f",
+              "methods": [
+                "lag4"
+              ]
+            }
+          ],
+          "variable_time_methods": [
             "pchip"
           ]
         }

--- a/config-files/jhtdb-config.json
+++ b/config-files/jhtdb-config.json
@@ -189,7 +189,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -244,7 +244,7 @@
         {
           "code": "p",
           "name": "Pressure",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -290,7 +290,7 @@
         {
           "code": "o",
           "name": "Position",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -341,7 +341,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -395,7 +395,7 @@
         {
           "code": "p",
           "name": "Pressure",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -473,7 +473,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -528,7 +528,7 @@
         {
           "code": "p",
           "name": "Pressure",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -574,7 +574,7 @@
         {
           "code": "o",
           "name": "Position",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -592,7 +592,7 @@
         {
           "code": "f",
           "name": "Force",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -648,7 +648,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -703,7 +703,7 @@
         {
           "code": "p",
           "name": "Pressure",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -749,7 +749,7 @@
         {
           "code": "o",
           "name": "Position",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -767,7 +767,7 @@
         {
           "code": "f",
           "name": "Force",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -823,7 +823,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -910,7 +910,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -960,7 +960,7 @@
         {
           "code": "p",
           "name": "Pressure",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1034,7 +1034,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1083,7 +1083,7 @@
         {
           "code": "p",
           "name": "Pressure",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1123,7 +1123,7 @@
         {
           "code": "t",
           "name": "Temperature",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1163,7 +1163,7 @@
         {
           "code": "e",
           "name": "Subgrid-scale Energy",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1236,7 +1236,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1286,7 +1286,7 @@
         {
           "code": "p",
           "name": "Pressure",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1327,7 +1327,7 @@
         {
           "code": "t",
           "name": "Temperature",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1368,7 +1368,7 @@
         {
           "code": "e",
           "name": "Subgrid-scale Energy",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1442,7 +1442,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1497,7 +1497,7 @@
         {
           "code": "p",
           "name": "Pressure",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1543,7 +1543,7 @@
         {
           "code": "b",
           "name": "Magnetic Field",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1598,7 +1598,7 @@
         {
           "code": "a",
           "name": "Vector Potential",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1653,7 +1653,7 @@
         {
           "code": "o",
           "name": "Position",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1671,7 +1671,7 @@
         {
           "code": "f",
           "name": "Force",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1727,7 +1727,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1782,7 +1782,7 @@
         {
           "code": "p",
           "name": "Pressure",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1828,7 +1828,7 @@
         {
           "code": "d",
           "name": "Density",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1874,7 +1874,7 @@
         {
           "code": "o",
           "name": "Position",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1925,7 +1925,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -1979,7 +1979,7 @@
         {
           "code": "t",
           "name": "Temperature",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -2057,7 +2057,7 @@
         {
           "code": "u",
           "name": "Velocity",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -2096,7 +2096,7 @@
         {
           "code": "p",
           "name": "Pressure",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",
@@ -2128,7 +2128,7 @@
         {
           "code": "o",
           "name": "Position",
-          "grided": false,
+          "gridded": false,
           "variable_operator_methods": [
             {
               "operator": "f",

--- a/config-files/jhtdb-config.json
+++ b/config-files/jhtdb-config.json
@@ -185,12 +185,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -236,7 +236,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -245,7 +245,7 @@
           "code": "p",
           "name": "Pressure",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -282,7 +282,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -291,7 +291,7 @@
           "code": "o",
           "name": "Position",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -301,7 +301,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "pchip"
           ]
         }
@@ -337,12 +337,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -388,7 +388,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         },
@@ -396,7 +396,7 @@
           "code": "p",
           "name": "Pressure",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -433,7 +433,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         }
@@ -469,12 +469,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -520,7 +520,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -529,7 +529,7 @@
           "code": "p",
           "name": "Pressure",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -566,7 +566,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -575,7 +575,7 @@
           "code": "o",
           "name": "Position",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -585,7 +585,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "pchip"
           ]
         },
@@ -593,7 +593,7 @@
           "code": "f",
           "name": "Force",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -607,7 +607,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -644,12 +644,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -695,7 +695,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -704,7 +704,7 @@
           "code": "p",
           "name": "Pressure",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -741,7 +741,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -750,7 +750,7 @@
           "code": "o",
           "name": "Position",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -760,7 +760,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "pchip"
           ]
         },
@@ -768,7 +768,7 @@
           "code": "f",
           "name": "Force",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -782,7 +782,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -819,12 +819,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -870,7 +870,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         }
@@ -906,12 +906,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -953,7 +953,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         },
@@ -961,7 +961,7 @@
           "code": "p",
           "name": "Pressure",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -994,7 +994,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         }
@@ -1030,12 +1030,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1076,7 +1076,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         },
@@ -1084,7 +1084,7 @@
           "code": "p",
           "name": "Pressure",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1116,7 +1116,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         },
@@ -1124,7 +1124,7 @@
           "code": "t",
           "name": "Temperature",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1156,7 +1156,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         },
@@ -1164,7 +1164,7 @@
           "code": "e",
           "name": "Subgrid-scale Energy",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1196,7 +1196,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         }
@@ -1232,12 +1232,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1278,7 +1278,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1287,7 +1287,7 @@
           "code": "p",
           "name": "Pressure",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1319,7 +1319,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1328,7 +1328,7 @@
           "code": "t",
           "name": "Temperature",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1360,7 +1360,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1369,7 +1369,7 @@
           "code": "e",
           "name": "Subgrid-scale Energy",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1401,7 +1401,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1438,12 +1438,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1489,7 +1489,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1498,7 +1498,7 @@
           "code": "p",
           "name": "Pressure",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1535,7 +1535,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1544,7 +1544,7 @@
           "code": "b",
           "name": "Magnetic Field",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1590,7 +1590,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1599,7 +1599,7 @@
           "code": "a",
           "name": "Vector Potential",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1645,7 +1645,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1654,7 +1654,7 @@
           "code": "o",
           "name": "Position",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1664,7 +1664,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "pchip"
           ]
         },
@@ -1672,7 +1672,7 @@
           "code": "f",
           "name": "Force",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1686,7 +1686,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1723,12 +1723,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1774,7 +1774,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1783,7 +1783,7 @@
           "code": "p",
           "name": "Pressure",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1820,7 +1820,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1829,7 +1829,7 @@
           "code": "d",
           "name": "Density",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1866,7 +1866,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -1875,7 +1875,7 @@
           "code": "o",
           "name": "Position",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1885,7 +1885,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "pchip"
           ]
         }
@@ -1921,12 +1921,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -1972,7 +1972,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         },
@@ -1980,7 +1980,7 @@
           "code": "t",
           "name": "Temperature",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -2017,7 +2017,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none"
           ]
         }
@@ -2053,12 +2053,12 @@
         }
       },
       "description": null,
-      "physical_variables": [
+      "physicalVariables": [
         {
           "code": "u",
           "name": "Velocity",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -2088,7 +2088,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -2097,7 +2097,7 @@
           "code": "p",
           "name": "Pressure",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -2120,7 +2120,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "none",
             "pchip"
           ]
@@ -2129,7 +2129,7 @@
           "code": "o",
           "name": "Position",
           "gridded": false,
-          "variable_operator_methods": [
+          "spatialOperatorMethods": [
             {
               "operator": "f",
               "methods": [
@@ -2137,7 +2137,7 @@
               ]
             }
           ],
-          "variable_time_methods": [
+          "temporalMethods": [
             "pchip"
           ]
         }


### PR DESCRIPTION
## Description
Changed the structure of `jhtdb-config.json` to change `physical_variables` field from a string array to an array of objects that now includes `variable_operator_methods`, `variable_time_methods` and `grided` fields.

I added the `variable_operator_methods` to the `physical_variables`, which is now an object, and noticed we had the same redundancy issues with `variable_time_methods`, so I included those in that new object as well. I also added the `grided` field we discussed and set its default to `false`.